### PR TITLE
Support for kernel version <3.9

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1295,12 +1295,17 @@ def new_socket():
     # Volume 2"), but some BSD-derived systems require
     # SO_REUSEPORT to be specified explicity.  Also, not all
     # versions of Python have SO_REUSEPORT available.
+    # Catch OSError for kernel versions <3.9 because lacking
+    # SO_REUSEPORT support.
     try:
         reuseport = socket.SO_REUSEPORT
     except AttributeError:
         pass
     else:
-        s.setsockopt(socket.SOL_SOCKET, reuseport, 1)
+        try:
+            s.setsockopt(socket.SOL_SOCKET, reuseport, 1)
+        except OSError:
+            pass
 
     s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 255)
     s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 1)


### PR DESCRIPTION
I found a problem running your module with a kernel prior version 3.9 (3.4 to be exact). SO_REUSEPORT causes a OSError when used with earlier kernel versions.

https://github.com/jstasiak/python-zeroconf/blob/master/zeroconf.py#L1303

[23:23:41] ERROR [ledd.daemon.register_zeroconf:136] Failed to register service with ZeroConf: [Errno 92] Protocol not available
Traceback (most recent call last):
  File "/home/user/LedD/ledd/daemon.py", line 132, in register_zeroconf
    zeroconf = Zeroconf()
  File "/usr/local/lib/python3.4/dist-packages/zeroconf.py", line 1336, in __init__
    self._listen_socket = new_socket()
  File "/usr/local/lib/python3.4/dist-packages/zeroconf.py", line 1303, in new_socket
    s.setsockopt(socket.SOL_SOCKET, reuseport, 1)
OSError: [Errno 92] Protocol not available

This machine runs python version 3.4.2 with kernel 3.4.

The line the exection occurs is this one: https://github.com/jstasiak/python-zeroconf/blob/master/zeroconf.py#L1303

I fixed it by adding a second try catch block to prevent the OSError from stopping the start on these kernel version.